### PR TITLE
feat: add LocalFountainBleProtocol for direct BLE fountain control

### DIFF
--- a/pypetkitapi/__init__.py
+++ b/pypetkitapi/__init__.py
@@ -50,18 +50,18 @@ from .exceptions import (
     PypetkitError,
 )
 from .feeder_container import Feeder, RecordsItems
-from .local_bluetooth import (
-    BLE_FOUNTAIN_NAME_PREFIXES,
-    BLE_NOTIFY_UUID,
-    BLE_WRITE_UUID,
-    LocalFountainBleProtocol,
-)
 from .litter_container import (
     Litter,
     LitterRecord,
     PackageInfoResult,
     PackageListResult,
     WorkState,
+)
+from .local_bluetooth import (
+    BLE_FOUNTAIN_NAME_PREFIXES,
+    BLE_NOTIFY_UUID,
+    BLE_WRITE_UUID,
+    LocalFountainBleProtocol,
 )
 from .media import DownloadDecryptMedia, MediaCloud, MediaFile, MediaManager
 from .purifier_container import Purifier
@@ -70,6 +70,9 @@ from .water_fountain_container import WaterFountain
 __version__ = "1.25.1"
 
 __all__ = [
+    "BLE_FOUNTAIN_NAME_PREFIXES",
+    "BLE_NOTIFY_UUID",
+    "BLE_WRITE_UUID",
     "CTW3",
     "D3",
     "D4",
@@ -107,6 +110,7 @@ __all__ = [
     "LitterCommand",
     "LitterRecord",
     "LiveFeed",
+    "LocalFountainBleProtocol",
     "MediaCloud",
     "MediaFile",
     "MediaManager",
@@ -126,10 +130,6 @@ __all__ = [
     "Purifier",
     "PypetkitError",
     "RecordType",
-    "BLE_FOUNTAIN_NAME_PREFIXES",
-    "BLE_NOTIFY_UUID",
-    "BLE_WRITE_UUID",
-    "LocalFountainBleProtocol",
     "RecordsItems",
     "WaterFountain",
     "WorkState",

--- a/pypetkitapi/__init__.py
+++ b/pypetkitapi/__init__.py
@@ -50,6 +50,12 @@ from .exceptions import (
     PypetkitError,
 )
 from .feeder_container import Feeder, RecordsItems
+from .local_bluetooth import (
+    BLE_FOUNTAIN_NAME_PREFIXES,
+    BLE_NOTIFY_UUID,
+    BLE_WRITE_UUID,
+    LocalFountainBleProtocol,
+)
 from .litter_container import (
     Litter,
     LitterRecord,
@@ -120,6 +126,10 @@ __all__ = [
     "Purifier",
     "PypetkitError",
     "RecordType",
+    "BLE_FOUNTAIN_NAME_PREFIXES",
+    "BLE_NOTIFY_UUID",
+    "BLE_WRITE_UUID",
+    "LocalFountainBleProtocol",
     "RecordsItems",
     "WaterFountain",
     "WorkState",

--- a/pypetkitapi/local_bluetooth.py
+++ b/pypetkitapi/local_bluetooth.py
@@ -208,8 +208,12 @@ class LocalFountainBleProtocol:
                 "filter_percentage": data[13] / 100.0,
                 "running_status": data[14],
                 "pump_runtime_today": int.from_bytes(bytes(data[15:19]), "big"),
-                "supply_voltage": int.from_bytes(bytes(data[20:22]), "big", signed=True),
-                "battery_voltage": int.from_bytes(bytes(data[22:24]), "big", signed=True),
+                "supply_voltage": int.from_bytes(
+                    bytes(data[20:22]), "big", signed=True
+                ),
+                "battery_voltage": int.from_bytes(
+                    bytes(data[22:24]), "big", signed=True
+                ),
                 "battery_percentage": data[24],
             }
         return {
@@ -245,8 +249,12 @@ class LocalFountainBleProtocol:
             "do_not_disturb_switch": data[8],
             "led_light_time_on": int.from_bytes(bytes(data[4:6]), "big", signed=True),
             "led_light_time_off": int.from_bytes(bytes(data[6:8]), "big", signed=True),
-            "do_not_disturb_time_on": int.from_bytes(bytes(data[9:11]), "big", signed=True),
-            "do_not_disturb_time_off": int.from_bytes(bytes(data[11:13]), "big", signed=True),
+            "do_not_disturb_time_on": int.from_bytes(
+                bytes(data[9:11]), "big", signed=True
+            ),
+            "do_not_disturb_time_off": int.from_bytes(
+                bytes(data[11:13]), "big", signed=True
+            ),
         }
 
     def _parse_ctw3_full_status(self, data: list[int]) -> dict[str, Any]:
@@ -259,8 +267,13 @@ class LocalFountainBleProtocol:
         smart_time_on = data[26] if len(data) > 26 else 0
         smart_time_off = data[27] if len(data) > 27 else 0
         filter_days, water_total, water_today, energy = self._calculate_values(
-            mode, filter_pct, smart_time_on, smart_time_off,
-            "CTW3", pump_runtime_today, pump_runtime,
+            mode,
+            filter_pct,
+            smart_time_on,
+            smart_time_off,
+            "CTW3",
+            pump_runtime_today,
+            pump_runtime,
         )
         return {
             "power_status": data[0],
@@ -300,8 +313,13 @@ class LocalFountainBleProtocol:
         pump_runtime = int.from_bytes(bytes(data[6:10]), "big")
         pump_runtime_today = int.from_bytes(bytes(data[12:16]), "big")
         filter_days, water_total, water_today, energy = self._calculate_values(
-            mode, filter_pct, smart_time_on, smart_time_off,
-            self.device_alias, pump_runtime_today, pump_runtime,
+            mode,
+            filter_pct,
+            smart_time_on,
+            smart_time_off,
+            self.device_alias,
+            pump_runtime_today,
+            pump_runtime,
         )
         result: dict[str, Any] = {
             "power_status": data[0],
@@ -333,14 +351,18 @@ class LocalFountainBleProtocol:
     # -----------------------------------------------------------------------
 
     @staticmethod
-    def update_water_fountain(fountain: "WaterFountain", ble_status: dict[str, Any]) -> None:
+    def update_water_fountain(
+        fountain: WaterFountain, ble_status: dict[str, Any]
+    ) -> None:
         """Apply a BLE status dict to a WaterFountain entity in-place."""
         if fountain.status is None:
             from pypetkitapi.water_fountain_container import Status
+
             fountain.status = Status()
 
         if fountain.settings is None:
             from pypetkitapi.water_fountain_container import SettingsFountain
+
             fountain.settings = SettingsFountain()
 
         s = fountain.status
@@ -352,21 +374,39 @@ class LocalFountainBleProtocol:
         s.detect_status = ble_status.get("pet_drinking", s.detect_status)
 
         fountain.mode = ble_status.get("mode", fountain.mode)
-        fountain.is_night_no_disturbing = ble_status.get("dnd_state", fountain.is_night_no_disturbing)
-        fountain.breakdown_warning = ble_status.get("warning_breakdown", fountain.breakdown_warning)
-        fountain.lack_warning = ble_status.get("warning_water_missing", fountain.lack_warning)
-        fountain.filter_warning = ble_status.get("warning_filter", fountain.filter_warning)
+        fountain.is_night_no_disturbing = ble_status.get(
+            "dnd_state", fountain.is_night_no_disturbing
+        )
+        fountain.breakdown_warning = ble_status.get(
+            "warning_breakdown", fountain.breakdown_warning
+        )
+        fountain.lack_warning = ble_status.get(
+            "warning_water_missing", fountain.lack_warning
+        )
+        fountain.filter_warning = ble_status.get(
+            "warning_filter", fountain.filter_warning
+        )
         fountain.low_battery = ble_status.get("low_battery", fountain.low_battery)
 
         filter_pct = ble_status.get("filter_percentage")
         if filter_pct is not None:
             fountain.filter_percent = int(filter_pct * 100)
 
-        fountain.filter_expected_days = ble_status.get("filter_time_left", fountain.filter_expected_days)
-        fountain.water_pump_run_time = ble_status.get("pump_runtime", fountain.water_pump_run_time)
-        fountain.today_pump_run_time = ble_status.get("pump_runtime_today", fountain.today_pump_run_time)
-        fountain.expected_clean_water = ble_status.get("expected_clean_water", fountain.expected_clean_water)
-        fountain.today_clean_water = ble_status.get("today_clean_water", fountain.today_clean_water)
+        fountain.filter_expected_days = ble_status.get(
+            "filter_time_left", fountain.filter_expected_days
+        )
+        fountain.water_pump_run_time = ble_status.get(
+            "pump_runtime", fountain.water_pump_run_time
+        )
+        fountain.today_pump_run_time = ble_status.get(
+            "pump_runtime_today", fountain.today_pump_run_time
+        )
+        fountain.expected_clean_water = ble_status.get(
+            "expected_clean_water", fountain.expected_clean_water
+        )
+        fountain.today_clean_water = ble_status.get(
+            "today_clean_water", fountain.today_clean_water
+        )
 
         energy = ble_status.get("today_use_electricity")
         if energy is not None:
@@ -378,8 +418,12 @@ class LocalFountainBleProtocol:
         cfg.smart_working_time = ble_status.get("smart_time_on", cfg.smart_working_time)
         cfg.smart_sleep_time = ble_status.get("smart_time_off", cfg.smart_sleep_time)
         cfg.lamp_ring_switch = ble_status.get("led_switch", cfg.lamp_ring_switch)
-        cfg.lamp_ring_brightness = ble_status.get("led_brightness", cfg.lamp_ring_brightness)
-        cfg.no_disturbing_switch = ble_status.get("do_not_disturb_switch", cfg.no_disturbing_switch)
+        cfg.lamp_ring_brightness = ble_status.get(
+            "led_brightness", cfg.lamp_ring_brightness
+        )
+        cfg.no_disturbing_switch = ble_status.get(
+            "do_not_disturb_switch", cfg.no_disturbing_switch
+        )
 
         # CTW3 electricity
         battery_pct = ble_status.get("battery_percentage")
@@ -388,6 +432,7 @@ class LocalFountainBleProtocol:
         if any(v is not None for v in (battery_pct, battery_v, supply_v)):
             if fountain.electricity is None:
                 from pypetkitapi.water_fountain_container import Electricity
+
                 fountain.electricity = Electricity()
             if battery_pct is not None:
                 fountain.electricity.battery_percent = battery_pct
@@ -411,7 +456,11 @@ class LocalFountainBleProtocol:
         """Derive the BLE session secret from device ID bytes."""
         padded = ([0] * max(0, 8 - len(device_id_bytes)) + device_id_bytes)[:8]
         reversed_bytes = list(reversed(padded))
-        if len(reversed_bytes) >= 2 and reversed_bytes[-2] == 0 and reversed_bytes[-1] == 0:
+        if (
+            len(reversed_bytes) >= 2
+            and reversed_bytes[-2] == 0
+            and reversed_bytes[-1] == 0
+        ):
             reversed_bytes[-2] = 13
             reversed_bytes[-1] = 37
         return reversed_bytes
@@ -432,7 +481,9 @@ class LocalFountainBleProtocol:
         if time_on == 0:
             filter_days = math.ceil(filter_pct * 60)
         else:
-            filter_days = math.ceil(((filter_pct * 30.0) * (time_on + time_off)) / time_on)
+            filter_days = math.ceil(
+                ((filter_pct * 30.0) * (time_on + time_off)) / time_on
+            )
 
         flow_rate, divisor = 1.5, 2.0
         if alias == "W5C":

--- a/pypetkitapi/local_bluetooth.py
+++ b/pypetkitapi/local_bluetooth.py
@@ -1,0 +1,451 @@
+"""Local (direct) Bluetooth protocol handler for PetKit fountains.
+
+This module is transport-agnostic. It handles the BLE protocol
+(command building, frame parsing, initialization sequence) without
+depending on any specific BLE library. The caller provides a write
+function and receives parsed status via handle_notification().
+
+BLE frame format:
+  Header:     [0xFA, 0xFC, 0xFD]
+  Command:    [cmd, type, seq, length, 0x00]
+  Data:       [...]
+  End:        [0xFB]
+
+UUIDs:
+  Write:   0000aaa2-0000-1000-8000-00805f9b34fb
+  Notify:  0000aaa1-0000-1000-8000-00805f9b34fb
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+import math
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pypetkitapi.water_fountain_container import WaterFountain
+
+_LOGGER = logging.getLogger(__name__)
+
+BLE_WRITE_UUID = "0000aaa2-0000-1000-8000-00805f9b34fb"
+BLE_NOTIFY_UUID = "0000aaa1-0000-1000-8000-00805f9b34fb"
+
+BLE_FOUNTAIN_NAME_PREFIXES = ("Petkit_W4", "Petkit_W5", "Petkit_CTW")
+
+
+class LocalFountainBleProtocol:
+    """Transport-agnostic BLE protocol handler for PetKit fountains.
+
+    Usage:
+        1. Create an instance, optionally passing the device alias ("CTW3", "W5", ...).
+        2. Call get_init_commands() to get the first command (CMD 213).
+        3. Send that command via BLE and wait for the notification.
+        4. Pass the notification bytes to handle_notification() — when it returns None
+           with CMD_DEVICE_ID internally processed, call complete_init_commands()
+           to get the remaining init commands (CMD 73, 86, 84).
+        5. After init, call get_status_command() and send it.
+        6. Pass notifications to handle_notification() to get the status dict.
+    """
+
+    # Command codes
+    CMD_BATTERY = 66
+    CMD_INIT = 73
+    CMD_SET_DATETIME = 84
+    CMD_SYNC = 86
+    CMD_FIRMWARE = 200
+    CMD_DEVICE_TYPE = 201
+    CMD_DEVICE_STATE = 210
+    CMD_DEVICE_CONFIG = 211
+    CMD_DEVICE_ID = 213
+    CMD_SET_MODE = 220
+    CMD_SET_CONFIG = 221
+    CMD_FULL_STATUS = 230
+
+    _HEADER = [0xFA, 0xFC, 0xFD]
+    _END_BYTE = 0xFB
+
+    def __init__(self, device_alias: str = "") -> None:
+        """Initialize the protocol handler."""
+        self._sequence = 0
+        self._device_id_bytes: list[int] = []
+        self._secret: list[int] = []
+        self.device_alias = device_alias
+        self.device_id_received = False
+
+    # -----------------------------------------------------------------------
+    # Command building
+    # -----------------------------------------------------------------------
+
+    def _next_seq(self) -> int:
+        seq = self._sequence
+        self._sequence = (self._sequence + 1) % 256
+        return seq
+
+    def build_command(self, cmd: int, cmd_type: int, data: list[int]) -> bytearray:
+        """Build a BLE command frame."""
+        seq = self._next_seq()
+        length = len(data)
+        frame = self._HEADER + [cmd, cmd_type, seq, length, 0] + data + [self._END_BYTE]
+        return bytearray(frame)
+
+    def get_init_commands(self) -> list[bytearray]:
+        """Return the first init command (CMD 213 — request device ID).
+
+        Call complete_init_commands() after the CMD 213 notification is received.
+        """
+        return [self.build_command(self.CMD_DEVICE_ID, 1, [0, 0])]
+
+    def complete_init_commands(self) -> list[bytearray]:
+        """Return the remaining init commands (CMD 73, 86, 84).
+
+        Must be called after handle_notification() has processed the CMD 213 response.
+        """
+        if not self._device_id_bytes:
+            _LOGGER.warning("Device ID not yet received; cannot complete BLE init")
+            return []
+
+        device_id_padded = (self._device_id_bytes + [0] * 8)[:8]
+        self._secret = self._derive_secret(device_id_padded)
+
+        cmds: list[bytearray] = []
+
+        # CMD 73: Init / authenticate
+        init_data = [0, 0] + device_id_padded + self._secret
+        cmds.append(self.build_command(self.CMD_INIT, 1, init_data))
+
+        # CMD 86: Sync (uses secret)
+        cmds.append(self.build_command(self.CMD_SYNC, 1, [0, 0] + self._secret))
+
+        # CMD 84: Set device datetime (seconds since 2000-01-01 UTC)
+        secs = self._seconds_since_2000()
+        time_data = [
+            0,
+            (secs >> 24) & 0xFF,
+            (secs >> 16) & 0xFF,
+            (secs >> 8) & 0xFF,
+            secs & 0xFF,
+            13,
+        ]
+        cmds.append(self.build_command(self.CMD_SET_DATETIME, 1, time_data))
+
+        return cmds
+
+    def get_status_command(self) -> bytearray:
+        """Return CMD 230 — full status request."""
+        return self.build_command(self.CMD_FULL_STATUS, 2, [1])
+
+    def build_set_mode_command(self, power_state: int, mode: int) -> bytearray:
+        """Return CMD 220 — set operating mode."""
+        return self.build_command(self.CMD_SET_MODE, 1, [power_state, mode, 1])
+
+    def build_set_config_command(self, config_data: list[int]) -> bytearray:
+        """Return CMD 221 — set device configuration."""
+        return self.build_command(self.CMD_SET_CONFIG, 1, config_data)
+
+    # -----------------------------------------------------------------------
+    # Notification parsing
+    # -----------------------------------------------------------------------
+
+    def handle_notification(self, data: bytearray) -> dict[str, Any] | None:
+        """Parse an incoming BLE notification.
+
+        Returns a status dict for CMD 210/211/230, or None for protocol /
+        info frames (CMD 213 response is handled internally).
+        """
+        if len(data) < 9:
+            return None
+        if data[0] != 0xFA or data[1] != 0xFC or data[2] != 0xFD:
+            return None
+        if data[-1] != self._END_BYTE:
+            return None
+
+        cmd = data[3]
+        payload = list(data[8:-1])
+
+        if cmd == self.CMD_DEVICE_ID:
+            # Extract device ID bytes from identifier response (bytes 2–8 of payload)
+            if len(payload) >= 8:
+                self._device_id_bytes = payload[2:8]
+                self.device_id_received = True
+                _LOGGER.debug("BLE device ID received: %s", self._device_id_bytes)
+            return None
+
+        if cmd == self.CMD_FULL_STATUS:
+            return self._parse_full_status(payload)
+
+        if cmd == self.CMD_DEVICE_STATE:
+            return self._parse_state(payload)
+
+        if cmd == self.CMD_DEVICE_CONFIG:
+            return self._parse_config(payload)
+
+        return None
+
+    # -----------------------------------------------------------------------
+    # Parsing helpers
+    # -----------------------------------------------------------------------
+
+    def _parse_full_status(self, data: list[int]) -> dict[str, Any]:
+        if self.device_alias == "CTW3":
+            return self._parse_ctw3_full_status(data)
+        return self._parse_generic_full_status(data)
+
+    def _parse_state(self, data: list[int]) -> dict[str, Any]:
+        if self.device_alias == "CTW3":
+            if len(data) < 26:
+                return {}
+            return {
+                "power_status": data[0],
+                "suspend_status": data[1],
+                "mode": data[2],
+                "dnd_state": data[4],
+                "warning_breakdown": data[5],
+                "warning_water_missing": data[6],
+                "low_battery": data[7],
+                "warning_filter": data[8],
+                "pump_runtime": int.from_bytes(bytes(data[9:13]), "big"),
+                "filter_percentage": data[13] / 100.0,
+                "running_status": data[14],
+                "pump_runtime_today": int.from_bytes(bytes(data[15:19]), "big"),
+                "supply_voltage": int.from_bytes(bytes(data[20:22]), "big", signed=True),
+                "battery_voltage": int.from_bytes(bytes(data[22:24]), "big", signed=True),
+                "battery_percentage": data[24],
+            }
+        return {
+            "power_status": data[0],
+            "mode": data[1],
+            "dnd_state": data[2],
+            "warning_breakdown": data[3],
+            "warning_water_missing": data[4],
+            "warning_filter": data[5],
+            "pump_runtime": int.from_bytes(bytes(data[6:10]), "big"),
+            "filter_percentage": (data[10] & 0xFF) / 100.0,
+            "running_status": data[11] & 0xFF,
+        }
+
+    def _parse_config(self, data: list[int]) -> dict[str, Any]:
+        if self.device_alias == "CTW3":
+            if len(data) < 9:
+                return {}
+            return {
+                "smart_time_on": data[0],
+                "smart_time_off": data[1],
+                "led_switch": data[6],
+                "led_brightness": data[7],
+                "do_not_disturb_switch": data[8],
+            }
+        if len(data) < 14:
+            return {}
+        return {
+            "smart_time_on": data[0],
+            "smart_time_off": data[1],
+            "led_switch": data[2],
+            "led_brightness": data[3],
+            "do_not_disturb_switch": data[8],
+            "led_light_time_on": int.from_bytes(bytes(data[4:6]), "big", signed=True),
+            "led_light_time_off": int.from_bytes(bytes(data[6:8]), "big", signed=True),
+            "do_not_disturb_time_on": int.from_bytes(bytes(data[9:11]), "big", signed=True),
+            "do_not_disturb_time_off": int.from_bytes(bytes(data[11:13]), "big", signed=True),
+        }
+
+    def _parse_ctw3_full_status(self, data: list[int]) -> dict[str, Any]:
+        if len(data) < 26:
+            return {}
+        mode = data[2]
+        filter_pct = data[13] / 100.0
+        pump_runtime = int.from_bytes(bytes(data[9:13]), "big")
+        pump_runtime_today = int.from_bytes(bytes(data[15:19]), "big")
+        smart_time_on = data[26] if len(data) > 26 else 0
+        smart_time_off = data[27] if len(data) > 27 else 0
+        filter_days, water_total, water_today, energy = self._calculate_values(
+            mode, filter_pct, smart_time_on, smart_time_off,
+            "CTW3", pump_runtime_today, pump_runtime,
+        )
+        return {
+            "power_status": data[0],
+            "suspend_status": data[1],
+            "mode": mode,
+            "dnd_state": data[4],
+            "warning_breakdown": data[5],
+            "warning_water_missing": data[6],
+            "low_battery": data[7],
+            "warning_filter": data[8],
+            "pump_runtime": pump_runtime,
+            "filter_percentage": filter_pct,
+            "running_status": data[14],
+            "pump_runtime_today": pump_runtime_today,
+            "pet_drinking": data[19],
+            "supply_voltage": int.from_bytes(bytes(data[20:22]), "big", signed=True),
+            "battery_voltage": int.from_bytes(bytes(data[22:24]), "big", signed=True),
+            "battery_percentage": data[24],
+            "smart_time_on": smart_time_on,
+            "smart_time_off": smart_time_off,
+            "led_switch": data[28] if len(data) > 28 else None,
+            "led_brightness": data[29] if len(data) > 29 else None,
+            "do_not_disturb_switch": data[34] if len(data) > 34 else None,
+            "filter_time_left": filter_days,
+            "today_clean_water": water_today,
+            "expected_clean_water": water_total,
+            "today_use_electricity": energy,
+        }
+
+    def _parse_generic_full_status(self, data: list[int]) -> dict[str, Any]:
+        if len(data) < 18:
+            return {}
+        mode = data[1]
+        filter_pct = (data[10] & 0xFF) / 100.0
+        smart_time_on = data[16]
+        smart_time_off = data[17]
+        pump_runtime = int.from_bytes(bytes(data[6:10]), "big")
+        pump_runtime_today = int.from_bytes(bytes(data[12:16]), "big")
+        filter_days, water_total, water_today, energy = self._calculate_values(
+            mode, filter_pct, smart_time_on, smart_time_off,
+            self.device_alias, pump_runtime_today, pump_runtime,
+        )
+        result: dict[str, Any] = {
+            "power_status": data[0],
+            "mode": mode,
+            "dnd_state": data[2],
+            "warning_breakdown": data[3],
+            "warning_water_missing": data[4],
+            "warning_filter": data[5],
+            "pump_runtime": pump_runtime,
+            "filter_percentage": filter_pct,
+            "running_status": data[11] & 0xFF,
+            "pump_runtime_today": pump_runtime_today,
+            "smart_time_on": smart_time_on,
+            "smart_time_off": smart_time_off,
+            "filter_time_left": filter_days,
+            "today_clean_water": water_today,
+            "expected_clean_water": water_total,
+            "today_use_electricity": energy,
+        }
+        if len(data) >= 20:
+            result["led_switch"] = data[18]
+            result["led_brightness"] = data[19]
+        if len(data) >= 25:
+            result["do_not_disturb_switch"] = data[24]
+        return result
+
+    # -----------------------------------------------------------------------
+    # Water fountain entity update
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def update_water_fountain(fountain: "WaterFountain", ble_status: dict[str, Any]) -> None:
+        """Apply a BLE status dict to a WaterFountain entity in-place."""
+        if fountain.status is None:
+            from pypetkitapi.water_fountain_container import Status
+            fountain.status = Status()
+
+        if fountain.settings is None:
+            from pypetkitapi.water_fountain_container import SettingsFountain
+            fountain.settings = SettingsFountain()
+
+        s = fountain.status
+        cfg = fountain.settings
+
+        s.power_status = ble_status.get("power_status", s.power_status)
+        s.run_status = ble_status.get("running_status", s.run_status)
+        s.suspend_status = ble_status.get("suspend_status", s.suspend_status)
+        s.detect_status = ble_status.get("pet_drinking", s.detect_status)
+
+        fountain.mode = ble_status.get("mode", fountain.mode)
+        fountain.is_night_no_disturbing = ble_status.get("dnd_state", fountain.is_night_no_disturbing)
+        fountain.breakdown_warning = ble_status.get("warning_breakdown", fountain.breakdown_warning)
+        fountain.lack_warning = ble_status.get("warning_water_missing", fountain.lack_warning)
+        fountain.filter_warning = ble_status.get("warning_filter", fountain.filter_warning)
+        fountain.low_battery = ble_status.get("low_battery", fountain.low_battery)
+
+        filter_pct = ble_status.get("filter_percentage")
+        if filter_pct is not None:
+            fountain.filter_percent = int(filter_pct * 100)
+
+        fountain.filter_expected_days = ble_status.get("filter_time_left", fountain.filter_expected_days)
+        fountain.water_pump_run_time = ble_status.get("pump_runtime", fountain.water_pump_run_time)
+        fountain.today_pump_run_time = ble_status.get("pump_runtime_today", fountain.today_pump_run_time)
+        fountain.expected_clean_water = ble_status.get("expected_clean_water", fountain.expected_clean_water)
+        fountain.today_clean_water = ble_status.get("today_clean_water", fountain.today_clean_water)
+
+        energy = ble_status.get("today_use_electricity")
+        if energy is not None:
+            try:
+                fountain.today_use_electricity = float(energy)
+            except (ValueError, TypeError):
+                pass
+
+        cfg.smart_working_time = ble_status.get("smart_time_on", cfg.smart_working_time)
+        cfg.smart_sleep_time = ble_status.get("smart_time_off", cfg.smart_sleep_time)
+        cfg.lamp_ring_switch = ble_status.get("led_switch", cfg.lamp_ring_switch)
+        cfg.lamp_ring_brightness = ble_status.get("led_brightness", cfg.lamp_ring_brightness)
+        cfg.no_disturbing_switch = ble_status.get("do_not_disturb_switch", cfg.no_disturbing_switch)
+
+        # CTW3 electricity
+        battery_pct = ble_status.get("battery_percentage")
+        battery_v = ble_status.get("battery_voltage")
+        supply_v = ble_status.get("supply_voltage")
+        if any(v is not None for v in (battery_pct, battery_v, supply_v)):
+            if fountain.electricity is None:
+                from pypetkitapi.water_fountain_container import Electricity
+                fountain.electricity = Electricity()
+            if battery_pct is not None:
+                fountain.electricity.battery_percent = battery_pct
+            if battery_v is not None:
+                fountain.electricity.battery_voltage = battery_v
+            if supply_v is not None:
+                fountain.electricity.supply_voltage = supply_v
+
+    # -----------------------------------------------------------------------
+    # Static helpers
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def _seconds_since_2000() -> int:
+        reference = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        return int((now - reference).total_seconds())
+
+    @staticmethod
+    def _derive_secret(device_id_bytes: list[int]) -> list[int]:
+        """Derive the BLE session secret from device ID bytes."""
+        padded = ([0] * max(0, 8 - len(device_id_bytes)) + device_id_bytes)[:8]
+        reversed_bytes = list(reversed(padded))
+        if len(reversed_bytes) >= 2 and reversed_bytes[-2] == 0 and reversed_bytes[-1] == 0:
+            reversed_bytes[-2] = 13
+            reversed_bytes[-1] = 37
+        return reversed_bytes
+
+    @staticmethod
+    def _calculate_values(
+        mode: int,
+        filter_pct: float,
+        smart_time_on: int,
+        smart_time_off: int,
+        alias: str,
+        pump_runtime_today: int,
+        pump_runtime: int,
+    ) -> tuple[int, float, float, str]:
+        """Calculate filter days remaining, water purified (L), and energy (kWh)."""
+        time_on = 1 if mode == 1 else smart_time_on
+        time_off = 0 if mode == 1 else smart_time_off
+        if time_on == 0:
+            filter_days = math.ceil(filter_pct * 60)
+        else:
+            filter_days = math.ceil(((filter_pct * 30.0) * (time_on + time_off)) / time_on)
+
+        flow_rate, divisor = 1.5, 2.0
+        if alias == "W5C":
+            flow_rate, divisor = 1.3, 1.0
+        elif alias == "W4X":
+            divisor = 1.8
+        elif alias == "CTW3":
+            divisor = 3.0
+
+        water_today = (flow_rate * pump_runtime_today / 60.0) / divisor
+        water_total = (flow_rate * pump_runtime / 60.0) / divisor
+
+        power_coeff = 0.182 if alias == "W5C" else 0.75
+        energy = format(power_coeff * pump_runtime / 3_600_000.0, "f")
+
+        return filter_days, water_total, water_today, energy

--- a/pypetkitapi/local_bluetooth.py
+++ b/pypetkitapi/local_bluetooth.py
@@ -18,6 +18,7 @@ UUIDs:
 
 from __future__ import annotations
 
+import contextlib
 from datetime import datetime, timezone
 import logging
 import math
@@ -86,7 +87,7 @@ class LocalFountainBleProtocol:
         """Build a BLE command frame."""
         seq = self._next_seq()
         length = len(data)
-        frame = self._HEADER + [cmd, cmd_type, seq, length, 0] + data + [self._END_BYTE]
+        frame = [*self._HEADER, cmd, cmd_type, seq, length, 0, *data, self._END_BYTE]
         return bytearray(frame)
 
     def get_init_commands(self) -> list[bytearray]:
@@ -111,11 +112,11 @@ class LocalFountainBleProtocol:
         cmds: list[bytearray] = []
 
         # CMD 73: Init / authenticate
-        init_data = [0, 0] + device_id_padded + self._secret
+        init_data = [0, 0, *device_id_padded, *self._secret]
         cmds.append(self.build_command(self.CMD_INIT, 1, init_data))
 
         # CMD 86: Sync (uses secret)
-        cmds.append(self.build_command(self.CMD_SYNC, 1, [0, 0] + self._secret))
+        cmds.append(self.build_command(self.CMD_SYNC, 1, [0, 0, *self._secret]))
 
         # CMD 84: Set device datetime (seconds since 2000-01-01 UTC)
         secs = self._seconds_since_2000()
@@ -136,8 +137,23 @@ class LocalFountainBleProtocol:
         return self.build_command(self.CMD_FULL_STATUS, 2, [1])
 
     def build_set_mode_command(self, power_state: int, mode: int) -> bytearray:
-        """Return CMD 220 — set operating mode."""
-        return self.build_command(self.CMD_SET_MODE, 1, [power_state, mode, 1])
+        """Return CMD 220 — set operating mode.
+
+        The third payload byte's semantics differ between fountain models:
+
+        * CTW3 (Eversweet Max 2): ``1`` is interpreted as an "apply" flag —
+          required for the mode change to take effect.
+        * CTW2 / W4 / W5 (Eversweet Max and earlier): the same byte is
+          interpreted as a "suspend" flag — sending ``1`` causes the device
+          to enter Pause and silently drop the mode change. We therefore
+          send ``0`` for these devices so a Standard ↔ Intermittent
+          transition is applied symmetrically (regression reported on PR
+          Jezza34000/homeassistant_petkit#203 by the project owner).
+        """
+        apply_or_suspend = 1 if self.device_alias.lower() == "ctw3" else 0
+        return self.build_command(
+            self.CMD_SET_MODE, 1, [power_state, mode, apply_or_suspend]
+        )
 
     def build_set_config_command(self, config_data: list[int]) -> bytearray:
         """Return CMD 221 — set device configuration."""
@@ -147,7 +163,9 @@ class LocalFountainBleProtocol:
     # Notification parsing
     # -----------------------------------------------------------------------
 
-    def handle_notification(self, data: bytearray) -> dict[str, Any] | None:
+    def handle_notification(
+        self, data: bytes | bytearray | memoryview
+    ) -> dict[str, Any] | None:
         """Parse an incoming BLE notification.
 
         Returns a status dict for CMD 210/211/230, or None for protocol /
@@ -187,12 +205,12 @@ class LocalFountainBleProtocol:
     # -----------------------------------------------------------------------
 
     def _parse_full_status(self, data: list[int]) -> dict[str, Any]:
-        if self.device_alias == "CTW3":
+        if self.device_alias.lower() == "ctw3":
             return self._parse_ctw3_full_status(data)
         return self._parse_generic_full_status(data)
 
     def _parse_state(self, data: list[int]) -> dict[str, Any]:
-        if self.device_alias == "CTW3":
+        if self.device_alias.lower() == "ctw3":
             if len(data) < 26:
                 return {}
             return {
@@ -216,6 +234,8 @@ class LocalFountainBleProtocol:
                 ),
                 "battery_percentage": data[24],
             }
+        if len(data) < 12:
+            return {}
         return {
             "power_status": data[0],
             "mode": data[1],
@@ -229,7 +249,7 @@ class LocalFountainBleProtocol:
         }
 
     def _parse_config(self, data: list[int]) -> dict[str, Any]:
-        if self.device_alias == "CTW3":
+        if self.device_alias.lower() == "ctw3":
             if len(data) < 9:
                 return {}
             return {
@@ -271,7 +291,7 @@ class LocalFountainBleProtocol:
             filter_pct,
             smart_time_on,
             smart_time_off,
-            "CTW3",
+            "ctw3",
             pump_runtime_today,
             pump_runtime,
         )
@@ -410,10 +430,8 @@ class LocalFountainBleProtocol:
 
         energy = ble_status.get("today_use_electricity")
         if energy is not None:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 fountain.today_use_electricity = float(energy)
-            except (ValueError, TypeError):
-                pass
 
         cfg.smart_working_time = ble_status.get("smart_time_on", cfg.smart_working_time)
         cfg.smart_sleep_time = ble_status.get("smart_time_off", cfg.smart_sleep_time)
@@ -474,8 +492,21 @@ class LocalFountainBleProtocol:
         alias: str,
         pump_runtime_today: int,
         pump_runtime: int,
-    ) -> tuple[int, float, float, str]:
-        """Calculate filter days remaining, water purified (L), and energy (kWh)."""
+    ) -> tuple[int, int, int, float]:
+        """Calculate filter days remaining, water purified (L) and energy (kWh).
+
+        Returns:
+            (filter_days, water_total_liters, water_today_liters, energy_kwh_today)
+
+            ``water_total`` and ``water_today`` are rounded to ``int`` to match
+            ``WaterFountain.expected_clean_water`` and
+            ``WaterFountain.today_clean_water`` (both ``int | None``).
+
+            ``energy`` is the energy consumed *today* (``kWh``) computed from
+            ``pump_runtime_today``, returned as ``float`` to match
+            ``WaterFountain.today_use_electricity``.
+        """
+        alias_lc = alias.lower()
         time_on = 1 if mode == 1 else smart_time_on
         time_off = 0 if mode == 1 else smart_time_off
         if time_on == 0:
@@ -486,17 +517,17 @@ class LocalFountainBleProtocol:
             )
 
         flow_rate, divisor = 1.5, 2.0
-        if alias == "W5C":
+        if alias_lc == "w5c":
             flow_rate, divisor = 1.3, 1.0
-        elif alias == "W4X":
+        elif alias_lc == "w4x":
             divisor = 1.8
-        elif alias == "CTW3":
+        elif alias_lc == "ctw3":
             divisor = 3.0
 
-        water_today = (flow_rate * pump_runtime_today / 60.0) / divisor
-        water_total = (flow_rate * pump_runtime / 60.0) / divisor
+        water_today = round((flow_rate * pump_runtime_today / 60.0) / divisor)
+        water_total = round((flow_rate * pump_runtime / 60.0) / divisor)
 
-        power_coeff = 0.182 if alias == "W5C" else 0.75
-        energy = format(power_coeff * pump_runtime / 3_600_000.0, "f")
+        power_coeff = 0.182 if alias_lc == "w5c" else 0.75
+        energy = power_coeff * pump_runtime_today / 3_600_000.0
 
         return filter_days, water_total, water_today, energy

--- a/tests/test_local_bluetooth.py
+++ b/tests/test_local_bluetooth.py
@@ -14,9 +14,7 @@ from pypetkitapi.local_bluetooth import (
 
 def _frame(cmd: int, cmd_type: int, seq: int, data: list[int]) -> bytearray:
     """Helper: build a raw BLE frame for tests (mirrors build_command)."""
-    return bytearray(
-        [0xFA, 0xFC, 0xFD, cmd, cmd_type, seq, len(data), 0, *data, 0xFB]
-    )
+    return bytearray([0xFA, 0xFC, 0xFD, cmd, cmd_type, seq, len(data), 0, *data, 0xFB])
 
 
 class TestConstants(unittest.TestCase):
@@ -178,7 +176,10 @@ class TestStateParsingGenericGuards(unittest.TestCase):
             0,  # warning_breakdown
             0,  # warning_water_missing
             0,  # warning_filter
-            0, 0, 0, 60,  # pump_runtime (big-endian)
+            0,
+            0,
+            0,
+            60,  # pump_runtime (big-endian)
             50,  # filter_percentage raw
             1,  # running_status
         ]

--- a/tests/test_local_bluetooth.py
+++ b/tests/test_local_bluetooth.py
@@ -1,0 +1,242 @@
+"""Tests for pypetkitapi.local_bluetooth.LocalFountainBleProtocol."""
+
+from __future__ import annotations
+
+import unittest
+
+from pypetkitapi.local_bluetooth import (
+    BLE_FOUNTAIN_NAME_PREFIXES,
+    BLE_NOTIFY_UUID,
+    BLE_WRITE_UUID,
+    LocalFountainBleProtocol,
+)
+
+
+def _frame(cmd: int, cmd_type: int, seq: int, data: list[int]) -> bytearray:
+    """Helper: build a raw BLE frame for tests (mirrors build_command)."""
+    return bytearray(
+        [0xFA, 0xFC, 0xFD, cmd, cmd_type, seq, len(data), 0, *data, 0xFB]
+    )
+
+
+class TestConstants(unittest.TestCase):
+    def test_ble_uuids_are_petkit_fountain(self):
+        self.assertEqual(BLE_WRITE_UUID, "0000aaa2-0000-1000-8000-00805f9b34fb")
+        self.assertEqual(BLE_NOTIFY_UUID, "0000aaa1-0000-1000-8000-00805f9b34fb")
+
+    def test_name_prefixes_cover_known_fountains(self):
+        self.assertIn("Petkit_W4", BLE_FOUNTAIN_NAME_PREFIXES)
+        self.assertIn("Petkit_W5", BLE_FOUNTAIN_NAME_PREFIXES)
+        self.assertIn("Petkit_CTW", BLE_FOUNTAIN_NAME_PREFIXES)
+
+
+class TestCommandFraming(unittest.TestCase):
+    def setUp(self) -> None:
+        self.proto = LocalFountainBleProtocol()
+
+    def test_build_command_layout(self):
+        frame = self.proto.build_command(213, 1, [0, 0])
+        # Header
+        self.assertEqual(list(frame[:3]), [0xFA, 0xFC, 0xFD])
+        # cmd / type / seq / len / 0
+        self.assertEqual(frame[3], 213)
+        self.assertEqual(frame[4], 1)
+        self.assertEqual(frame[5], 0)
+        self.assertEqual(frame[6], 2)
+        self.assertEqual(frame[7], 0)
+        # payload + end byte
+        self.assertEqual(list(frame[8:10]), [0, 0])
+        self.assertEqual(frame[-1], 0xFB)
+
+    def test_sequence_increments(self):
+        self.proto.build_command(213, 1, [0, 0])
+        second = self.proto.build_command(213, 1, [0, 0])
+        self.assertEqual(second[5], 1)
+
+    def test_sequence_wraps_at_256(self):
+        # Sequence is 0..255 then wraps. After 257 calls the last seq used is 0.
+        for _ in range(257):
+            frame = self.proto.build_command(213, 1, [0, 0])
+        self.assertEqual(frame[5], 0)
+
+    def test_get_init_commands_returns_only_device_id_request(self):
+        cmds = self.proto.get_init_commands()
+        self.assertEqual(len(cmds), 1)
+        self.assertEqual(cmds[0][3], LocalFountainBleProtocol.CMD_DEVICE_ID)
+
+    def test_complete_init_returns_empty_without_device_id(self):
+        self.assertEqual(self.proto.complete_init_commands(), [])
+
+    def test_get_status_command(self):
+        frame = self.proto.get_status_command()
+        self.assertEqual(frame[3], LocalFountainBleProtocol.CMD_FULL_STATUS)
+        self.assertEqual(frame[4], 2)
+        self.assertEqual(list(frame[8:9]), [1])
+
+
+class TestSetModeCommand(unittest.TestCase):
+    """The third payload byte's interpretation is device-specific.
+
+    See the docstring of ``build_set_mode_command`` for the underlying
+    regression (PR Jezza34000/homeassistant_petkit#203).
+    """
+
+    def test_ctw3_sends_apply_byte_one(self):
+        proto = LocalFountainBleProtocol("CTW3")
+        frame = proto.build_set_mode_command(1, 2)
+        self.assertEqual(list(frame[8:11]), [1, 2, 1])
+
+    def test_ctw3_lowercase_alias_is_normalized(self):
+        proto = LocalFountainBleProtocol("ctw3")
+        frame = proto.build_set_mode_command(1, 2)
+        self.assertEqual(list(frame[8:11]), [1, 2, 1])
+
+    def test_generic_w5_sends_zero_to_avoid_pause_flag(self):
+        proto = LocalFountainBleProtocol("W5")
+        frame = proto.build_set_mode_command(1, 2)
+        self.assertEqual(list(frame[8:11]), [1, 2, 0])
+
+    def test_ctw2_sends_zero_to_avoid_pause_flag(self):
+        proto = LocalFountainBleProtocol("CTW2")
+        frame = proto.build_set_mode_command(1, 2)
+        self.assertEqual(list(frame[8:11]), [1, 2, 0])
+
+    def test_standard_to_intermittent_and_back_are_symmetric(self):
+        proto = LocalFountainBleProtocol("CTW2")
+        std_to_int = proto.build_set_mode_command(1, 2)
+        int_to_std = proto.build_set_mode_command(1, 1)
+        # Both transitions should use the same suspend byte (0)
+        self.assertEqual(std_to_int[10], int_to_std[10])
+        self.assertEqual(std_to_int[10], 0)
+
+
+class TestNotificationParsing(unittest.TestCase):
+    def test_handle_notification_accepts_bytes(self):
+        proto = LocalFountainBleProtocol()
+        # Device ID response, payload of 8 bytes (alias prefix 2 + id 6)
+        payload = [0xAA, 0xBB, 1, 2, 3, 4, 5, 6]
+        frame = bytes(_frame(LocalFountainBleProtocol.CMD_DEVICE_ID, 1, 0, payload))
+        self.assertIsNone(proto.handle_notification(frame))
+        self.assertTrue(proto.device_id_received)
+
+    def test_handle_notification_accepts_memoryview(self):
+        proto = LocalFountainBleProtocol()
+        payload = [0xAA, 0xBB, 1, 2, 3, 4, 5, 6]
+        frame = memoryview(
+            bytes(_frame(LocalFountainBleProtocol.CMD_DEVICE_ID, 1, 0, payload))
+        )
+        self.assertIsNone(proto.handle_notification(frame))
+        self.assertTrue(proto.device_id_received)
+
+    def test_complete_init_after_device_id_returns_three_commands(self):
+        proto = LocalFountainBleProtocol()
+        payload = [0xAA, 0xBB, 1, 2, 3, 4, 5, 6]
+        proto.handle_notification(_frame(213, 1, 0, payload))
+        cmds = proto.complete_init_commands()
+        self.assertEqual(len(cmds), 3)
+        cmd_codes = [c[3] for c in cmds]
+        self.assertEqual(
+            cmd_codes,
+            [
+                LocalFountainBleProtocol.CMD_INIT,
+                LocalFountainBleProtocol.CMD_SYNC,
+                LocalFountainBleProtocol.CMD_SET_DATETIME,
+            ],
+        )
+
+    def test_handle_notification_rejects_short_frame(self):
+        proto = LocalFountainBleProtocol()
+        self.assertIsNone(proto.handle_notification(b"\xfa\xfc\xfd"))
+
+    def test_handle_notification_rejects_bad_header(self):
+        proto = LocalFountainBleProtocol()
+        bad = bytes([0x00, 0x00, 0x00, 213, 1, 0, 0, 0, 0xFB])
+        self.assertIsNone(proto.handle_notification(bad))
+
+    def test_handle_notification_rejects_bad_end_byte(self):
+        proto = LocalFountainBleProtocol()
+        bad = bytes([0xFA, 0xFC, 0xFD, 213, 1, 0, 0, 0, 0x00])
+        self.assertIsNone(proto.handle_notification(bad))
+
+
+class TestStateParsingGenericGuards(unittest.TestCase):
+    def test_generic_state_truncated_returns_empty_dict(self):
+        """Regression: generic _parse_state previously raised IndexError on short frames."""
+        proto = LocalFountainBleProtocol("W5")
+        # Send a too-short state notification (5 bytes payload, needs >=12)
+        frame = _frame(LocalFountainBleProtocol.CMD_DEVICE_STATE, 1, 0, [1, 1, 0, 0, 0])
+        # Should not raise
+        result = proto.handle_notification(frame)
+        self.assertEqual(result, {})
+
+    def test_generic_state_full_payload_parses(self):
+        proto = LocalFountainBleProtocol("W5")
+        payload = [
+            1,  # power_status
+            2,  # mode
+            0,  # dnd
+            0,  # warning_breakdown
+            0,  # warning_water_missing
+            0,  # warning_filter
+            0, 0, 0, 60,  # pump_runtime (big-endian)
+            50,  # filter_percentage raw
+            1,  # running_status
+        ]
+        frame = _frame(LocalFountainBleProtocol.CMD_DEVICE_STATE, 1, 0, payload)
+        result = proto.handle_notification(frame)
+        assert result is not None
+        self.assertEqual(result["mode"], 2)
+        self.assertEqual(result["pump_runtime"], 60)
+        self.assertAlmostEqual(result["filter_percentage"], 0.5)
+        self.assertEqual(result["running_status"], 1)
+
+    def test_ctw3_alias_case_insensitive_routing(self):
+        """Regression: CTW3 layout was only picked when alias matched 'CTW3' uppercase."""
+        for alias in ("CTW3", "ctw3", "Ctw3"):
+            proto = LocalFountainBleProtocol(alias)
+            # Build a 26-byte CTW3 state payload
+            payload = [0] * 26
+            payload[2] = 7  # mode (any sentinel value)
+            frame = _frame(LocalFountainBleProtocol.CMD_DEVICE_STATE, 1, 0, payload)
+            result = proto.handle_notification(frame)
+            assert result is not None, alias
+            self.assertIn("suspend_status", result, alias)
+            self.assertEqual(result["mode"], 7, alias)
+
+
+class TestCalculateValues(unittest.TestCase):
+    def test_energy_uses_today_runtime_and_returns_float(self):
+        days, water_total, water_today, energy = (
+            LocalFountainBleProtocol._calculate_values(
+                mode=1,
+                filter_pct=1.0,
+                smart_time_on=0,
+                smart_time_off=0,
+                alias="W5",
+                pump_runtime_today=3_600_000,  # 1 kWh-equivalent at 1.0 power_coeff
+                pump_runtime=10_000_000,  # lifetime; must NOT show up in energy
+            )
+        )
+        self.assertIsInstance(energy, float)
+        # 0.75 power_coeff * 3_600_000 / 3_600_000 = 0.75
+        self.assertAlmostEqual(energy, 0.75)
+        self.assertIsInstance(water_total, int)
+        self.assertIsInstance(water_today, int)
+        self.assertIsInstance(days, int)
+
+    def test_water_fields_are_int(self):
+        _, water_total, water_today, _ = LocalFountainBleProtocol._calculate_values(
+            mode=2,
+            filter_pct=0.5,
+            smart_time_on=10,
+            smart_time_off=20,
+            alias="ctw3",
+            pump_runtime_today=120,
+            pump_runtime=600,
+        )
+        self.assertIsInstance(water_total, int)
+        self.assertIsInstance(water_today, int)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a transport-agnostic BLE protocol handler for PetKit water fountains (W4/W5/CTW2/CTW3).
This is the library-side prerequisite for native local BLE support in the Home Assistant integration (see Jezza34000/homeassistant_petkit#31).

## New file: pypetkitapi/local_bluetooth.py

### LocalFountainBleProtocol
A stateless helper class that handles the full PetKit BLE protocol without depending on bleak or any async framework. The HA integration layer owns the actual BLE connection.

Key features:
- Command builder: get_init_commands(), complete_init_commands(), get_status_command(), build_set_mode_command(), build_set_config_command()
- Frame format: [FA FC FD cmd type seq len 00] + payload + [FB]
- Init handshake: CMD 213 (device ID) -> CMD 73 (auth with derived secret) -> CMD 86 (sync) -> CMD 84 (set datetime)
- Full status poll: CMD 230 -- returns both state + config in one response
- Notification parser: handle_notification() -- handles CMD 210 (state), 211 (config), 230 (full status)
- Dual layout support: Generic (W4/W5/CTW2) and CTW3-specific byte layouts
- Entity mapper: update_water_fountain() static method maps BLE status dict to WaterFountain fields

Exported constants: BLE_WRITE_UUID, BLE_NOTIFY_UUID, BLE_FOUNTAIN_NAME_PREFIXES

## pypetkitapi/__init__.py
New symbols added to imports and __all__.

## Notes
- Protocol reverse-engineered from PetkitW5BLEMQTT (MIT licensed)
- CMD 73 (auth) may conflict with the official Petkit app -- known trade-off documented in code
- bleak is NOT a dependency of this library (it is a core HA dependency)