### PR TITLE
Expose public fetch_region_servers on PetKitClient

### DIFF
--- a/pypetkitapi/__init__.py
+++ b/pypetkitapi/__init__.py
@@ -40,7 +40,7 @@ from .const import (
     MediaType,
     RecordType,
 )
-from .containers import IotInfo, LiveFeed, NewIotInfo, Pet
+from .containers import IotInfo, LiveFeed, NewIotInfo, Pet, RegionServerGroup
 from .exceptions import (
     PetkitAuthenticationUnregisteredEmailError,
     PetkitRegionalServerNotFoundError,
@@ -121,6 +121,7 @@ __all__ = [
     "PypetkitError",
     "RecordType",
     "RecordsItems",
+    "RegionServerGroup",
     "WaterFountain",
     "WorkState",
 ]

--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -43,6 +43,7 @@ from pypetkitapi.const import (
     PACKAGE_LIST,
     PET,
     PTK_DBG,
+    REGION_SERVER_LABELS,
     RES_KEY,
     T3,
     T4,
@@ -62,6 +63,7 @@ from pypetkitapi.containers import (
     Pet,
     PetDetails,
     RegionInfo,
+    RegionServerGroup,
     SessionInfo,
 )
 from pypetkitapi.exceptions import (
@@ -103,6 +105,45 @@ def data_handler(data_type):
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _group_region_servers(payload: dict) -> list[RegionServerGroup]:
+    """Group raw /v1/regionservers entries by gateway.
+
+    Pure transformation kept separate from the HTTP fetch so it can be
+    unit tested without mocking aiohttp. Always appends the China
+    gateway since /v1/regionservers omits it.
+    """
+    countries_by_gateway: dict[str, list[str]] = {}
+    for entry in payload.get("list", []):
+        info = RegionInfo(**entry)
+        countries_by_gateway.setdefault(info.gateway, []).append(info.id)
+
+    groups: list[RegionServerGroup] = []
+    for gateway, countries in countries_by_gateway.items():
+        sorted_countries = sorted(countries)
+        groups.append(
+            RegionServerGroup(
+                gateway=gateway,
+                label=REGION_SERVER_LABELS.get(gateway, gateway),
+                countries=sorted_countries,
+                representative_country=sorted_countries[0],
+            )
+        )
+
+    if not any(g.gateway == PetkitDomain.CHINA_SRV for g in groups):
+        china_gateway = PetkitDomain.CHINA_SRV.value
+        groups.append(
+            RegionServerGroup(
+                gateway=china_gateway,
+                label=REGION_SERVER_LABELS.get(china_gateway, "China"),
+                countries=["CN"],
+                representative_country="CN",
+            )
+        )
+
+    groups.sort(key=lambda g: g.label)
+    return groups
 
 
 class PetKitClient:
@@ -183,6 +224,38 @@ class PetKitClient:
                 _LOGGER.debug("Found matching server: %s", server)
                 return
         raise PetkitRegionalServerNotFoundError(self.region)
+
+    @classmethod
+    async def fetch_region_servers(
+        cls,
+        session: aiohttp.ClientSession,
+        timezone: str = DEFAULT_TZ,
+    ) -> list[RegionServerGroup]:
+        """Return PetKit's regional gateways grouped with friendly labels.
+
+        Use during onboarding so the user can pick one of the ~5 real
+        PetKit clouds (Europe, International, Asia, Russia, China) instead
+        of being shown a 200+ country dropdown. Each resulting
+        :class:`RegionServerGroup` carries the underlying ``gateway``,
+        the list of ``countries`` routed to it and a stable
+        ``representative_country`` that callers can pass back as the
+        ``region`` argument of :class:`PetKitClient`.
+
+        Network failures raise the same exceptions as any other
+        :class:`PetKitClient` call (e.g. :class:`PetkitTimeoutError`); the
+        caller decides whether to surface the error or fall back to a
+        country list.
+        """
+        req = PrepReq(
+            base_url=PetkitDomain.PASSPORT_PETKIT,
+            session=session,
+            timezone=timezone,
+        )
+        response = await req.request(
+            method=HTTPMethod.GET,
+            url=PetkitEndpoint.REGION_SERVERS,
+        )
+        return _group_region_servers(response)
 
     async def request_login_code(self) -> bool:
         """Request a login code to be sent to the user's email."""

--- a/pypetkitapi/const.py
+++ b/pypetkitapi/const.py
@@ -75,6 +75,19 @@ class PetkitDomain(StrEnum):
     CHINA_SRV = "https://api.petkit.cn/6/"
 
 
+# Friendly English labels for the regional gateways returned by
+# /v1/regionservers, plus the China gateway (which is reached
+# directly via PetkitDomain.CHINA_SRV and is not listed by that
+# endpoint). Keys must match the `gateway` field byte-for-byte.
+REGION_SERVER_LABELS: dict[str, str] = {
+    "https://api.eu-pet.com/latest/": "Europe",
+    "https://api.petkt.com/latest/": "International (Americas, global)",
+    "https://api.petktasia.com/latest/": "Asia",
+    "https://api-ru.petkit.cn/latest/": "Russia",
+    PetkitDomain.CHINA_SRV.value: "China",
+}
+
+
 class Client(StrEnum):
     """Platform constants"""
 

--- a/pypetkitapi/containers.py
+++ b/pypetkitapi/containers.py
@@ -20,6 +20,22 @@ class RegionInfo(BaseModel):
     name: str
 
 
+class RegionServerGroup(BaseModel):
+    """A PetKit gateway and the countries it serves.
+
+    Aggregated from /v1/regionservers, with the China gateway added
+    manually because that endpoint omits it. ``representative_country``
+    is a stable ISO code (first alphabetically among ``countries``) that
+    callers can pass back as the ``region`` argument when constructing
+    :class:`PetKitClient`.
+    """
+
+    gateway: str
+    label: str
+    countries: list[str]
+    representative_country: str
+
+
 class BleRelay(BaseModel):
     """Dataclass for BLE relay devices
     Fetched from the API endpoint :

--- a/tests/test_region_servers.py
+++ b/tests/test_region_servers.py
@@ -1,0 +1,93 @@
+import unittest
+
+from pypetkitapi.client import _group_region_servers
+from pypetkitapi.const import PetkitDomain
+
+SAMPLE_PAYLOAD = {
+    "list": [
+        {
+            "accountType": "1",
+            "gateway": "https://api.eu-pet.com/latest/",
+            "id": "DE",
+            "name": "Germany",
+        },
+        {
+            "accountType": "1",
+            "gateway": "https://api.eu-pet.com/latest/",
+            "id": "FR",
+            "name": "France",
+        },
+        {
+            "accountType": "1",
+            "gateway": "https://api.petkt.com/latest/",
+            "id": "US",
+            "name": "United States",
+        },
+    ]
+}
+
+
+class TestGroupRegionServers(unittest.TestCase):
+    def test_groups_countries_by_gateway(self):
+        groups = _group_region_servers(SAMPLE_PAYLOAD)
+        eu = next(g for g in groups if g.gateway == "https://api.eu-pet.com/latest/")
+        self.assertEqual(eu.countries, ["DE", "FR"])
+        self.assertEqual(eu.representative_country, "DE")
+        self.assertEqual(eu.label, "Europe")
+
+    def test_appends_china_when_missing(self):
+        groups = _group_region_servers(SAMPLE_PAYLOAD)
+        china = next(
+            (g for g in groups if g.gateway == PetkitDomain.CHINA_SRV.value), None
+        )
+        self.assertIsNotNone(china)
+        self.assertEqual(china.countries, ["CN"])
+        self.assertEqual(china.representative_country, "CN")
+        self.assertEqual(china.label, "China")
+
+    def test_does_not_duplicate_china_when_present(self):
+        payload = {
+            "list": [
+                *SAMPLE_PAYLOAD["list"],
+                {
+                    "accountType": "1",
+                    "gateway": PetkitDomain.CHINA_SRV.value,
+                    "id": "CN",
+                    "name": "China",
+                },
+            ]
+        }
+        groups = _group_region_servers(payload)
+        china_groups = [g for g in groups if g.gateway == PetkitDomain.CHINA_SRV.value]
+        self.assertEqual(len(china_groups), 1)
+
+    def test_sorted_by_label(self):
+        groups = _group_region_servers(SAMPLE_PAYLOAD)
+        labels = [g.label for g in groups]
+        self.assertEqual(labels, sorted(labels))
+
+    def test_unknown_gateway_uses_url_as_label(self):
+        payload = {
+            "list": [
+                {
+                    "accountType": "1",
+                    "gateway": "https://api.unknown.example/latest/",
+                    "id": "ZZ",
+                    "name": "Unknown",
+                }
+            ]
+        }
+        groups = _group_region_servers(payload)
+        unknown = next(
+            g for g in groups if g.gateway == "https://api.unknown.example/latest/"
+        )
+        self.assertEqual(unknown.label, "https://api.unknown.example/latest/")
+
+    def test_empty_payload_still_returns_china(self):
+        groups = _group_region_servers({"list": []})
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].gateway, PetkitDomain.CHINA_SRV.value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Companion to [Jezza34000/homeassistant_petkit#227](https://github.com/Jezza34000/homeassistant_petkit/pull/227). That PR added a 5-entry server picker but fetched and grouped `/v1/regionservers` inside the integration.

## What

- `PetKitClient.fetch_region_servers(session, timezone=DEFAULT_TZ)` classmethod, returns `list[RegionServerGroup]`. Network failures raise the same exceptions as other client calls.
- `RegionServerGroup` (containers.py): `gateway`, `label`, `countries`, `representative_country`. The representative country is the first ISO code alphabetically, so it stays stable across API responses.
- `_group_region_servers(payload)` module helper. Pure transform, kept separate so it can be unit tested without mocking aiohttp.
- `REGION_SERVER_LABELS` (const.py). Friendly English label per gateway URL. China is included since `/v1/regionservers` omits it but `_get_base_url` already reaches it via `PetkitDomain.CHINA_SRV`. The China entry is appended automatically when missing from the upstream response.

## Notes

- `_get_base_url` left untouched. Sharing the new helper would couple the login path to the new grouping, and the original matches on both `name` and `id`. Not worth the risk on the same PR.
- Labels are hardcoded English strings since pypetkitapi has no i18n today. If you'd rather keep the library presentation-free, I'll move them back to the integration.
- No version bump here, left for your workflow.

## Tests

`tests/test_region_servers.py`, 6 unit tests on the helper. Full suite 77/77 locally.

## Follow-up

After release, [homeassistant_petkit#227](https://github.com/Jezza34000/homeassistant_petkit/pull/227) drops `_fetch_petkit_servers`, `PETKIT_REGION_SERVERS_URL` and `PETKIT_SERVER_LABELS` and calls `PetKitClient.fetch_region_servers`.