### PR TITLE
Add W7H to CONTROL_DEVICE supported devices

### DIFF
--- a/pypetkitapi/command.py
+++ b/pypetkitapi/command.py
@@ -292,7 +292,7 @@ ACTIONS_MAP = {
             "kv": json.dumps(command),
             "type": list(command.keys())[0].split("_")[0],
         },
-        supported_device=[K2, K3, T3, T4, T5, T6, T7, COZY],
+        supported_device=[K2, K3, T3, T4, T5, T6, T7, COZY, W7H],
     ),
     DeviceCommand.OPEN_CAMERA: CmdData(
         endpoint=PetkitEndpoint.TEMP_OPEN_CAMERA,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -18,7 +18,7 @@ from pypetkitapi.command import (
     get_endpoint_save_repeats,
     ACTIONS_MAP,
 )
-from pypetkitapi.const import PetkitEndpoint, FEEDER_MINI, FEEDER, D3, D4H
+from pypetkitapi.const import PetkitEndpoint, FEEDER_MINI, FEEDER, D3, D4H, W7H
 
 
 class TestCommandModule(unittest.TestCase):
@@ -93,6 +93,12 @@ class TestCommandModule(unittest.TestCase):
     def test_actions_map(self):
         self.assertIn(DeviceCommand.UPDATE_SETTING, ACTIONS_MAP)
         self.assertIsInstance(ACTIONS_MAP[DeviceCommand.UPDATE_SETTING], CmdData)
+
+    def test_actions_map_control_device_supports_w7h(self):
+        """Test that CONTROL_DEVICE supports W7H fountain device."""
+        self.assertIn(DeviceCommand.CONTROL_DEVICE, ACTIONS_MAP)
+        supported = ACTIONS_MAP[DeviceCommand.CONTROL_DEVICE].supported_device
+        self.assertIn(W7H, supported)
 
     def test_feeder_command_save_feed(self):
         """Test that SAVE_FEED is defined in FeederCommand."""


### PR DESCRIPTION
## Summary

Adds `W7H` to the `DeviceCommand.CONTROL_DEVICE` entry in `ACTIONS_MAP`, enabling HTTP `controlDevice` commands for the EverSweet Ultra (W7H) cloud water fountain.

Without this, W7H maintenance actions (refill, drain, drain+flush, deep clean) invoked via `send_api_request(..., DeviceCommand.CONTROL_DEVICE, ...)` are rejected by the client before the API call is made.

**Companion integration PR:** Jezza34000/homeassistant_petkit#265

## Changes

- `pypetkitapi/command.py`: add `W7H` to `CONTROL_DEVICE` `supported_device` list (one line)

## Test plan

- [ ] `send_api_request(device_id, DeviceCommand.CONTROL_DEVICE, {DeviceAction.START: FountainActionWIFI.REFILL})` succeeds for a W7H device
- [ ] Other device types using `CONTROL_DEVICE` are unaffected
- [ ] Verified with Home Assistant Petkit integration PR #265 on a real W7H fountain