### PR TITLE
Per-pet meal stats from feeder records

### DIFF
--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -1016,7 +1016,7 @@ class PetKitClient:
         device_nfo = feeder_data.device_nfo
         return (
             device_nfo.device_type in FEEDER_WITH_CAMERA
-            and getattr(device_nfo, "type_code", 0) == 2
+            and device_nfo.type_code == 2
         )
 
     @staticmethod

--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -1015,8 +1015,7 @@ class PetKitClient:
         """Return True only for camera feeders exposing the AI/pet-recognition mode."""
         device_nfo = feeder_data.device_nfo
         return (
-            device_nfo.device_type in FEEDER_WITH_CAMERA
-            and device_nfo.type_code == 2
+            device_nfo.device_type in FEEDER_WITH_CAMERA and device_nfo.type_code == 2
         )
 
     @staticmethod

--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -1002,10 +1002,27 @@ class PetKitClient:
             )
             return
 
+        if not self._feeder_has_pet_recognition(feeder_data):
+            return
+
         pets_list = await self.get_pets_list()
         for pet in pets_list:
             await self.init_pet_feeder_stats(pet)
             await self._process_feeder_records(pet, feeder_data)
+
+    @staticmethod
+    def _feeder_has_pet_recognition(feeder_data: Feeder) -> bool:
+        """Return True only if the feeder payload contains at least one
+        eat record item attributed to a pet (i.e. has AI recognition).
+        """
+        records = getattr(feeder_data, "device_records", None)
+        if records is None or not getattr(records, "eat", None):
+            return False
+        for group in records.eat or []:
+            for item in getattr(group, "items", None) or []:
+                if item.pet_id is not None:
+                    return True
+        return False
 
     @staticmethod
     async def init_pet_feeder_stats(pet: Pet) -> None:

--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -1012,21 +1012,12 @@ class PetKitClient:
 
     @staticmethod
     def _feeder_has_pet_recognition(feeder_data: Feeder) -> bool:
-        """Return True if the feeder SUPPORTS pet recognition.
-
-        This is a capability test, not a data test. Looking for an already
-        attributed eat record conflates "cannot do this" with "has not done it
-        yet today": device_records.eat resets daily, and the AI does not
-        recognise every visit, so a data test leaves the stats uninitialised
-        for a window after every midnight.
-
-        `eatDetection` is the per-pet meal-event feature and is only present on
-        feeders that have it. `petDetection` is NOT usable here: it drives the
-        recognition overlay, and turning it off leaves per-pet attribution
-        working.
-        """
-        settings = getattr(feeder_data, "settings", None)
-        return settings is not None and settings.eat_detection is not None
+        """Return True only for camera feeders exposing the AI/pet-recognition mode."""
+        device_nfo = feeder_data.device_nfo
+        return (
+                device_nfo.device_type in FEEDER_WITH_CAMERA
+                and getattr(device_nfo, "type_code", 0) == 2
+        )
 
     @staticmethod
     async def init_pet_feeder_stats(pet: Pet) -> None:

--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -770,10 +770,15 @@ class PetKitClient:
 
     async def _execute_stats_tasks(self) -> None:
         """Execute tasks to populate pet stats."""
-        stats_tasks = [
+        stats_tasks: list = [
             self.populate_pet_stats(entity)
             for device_id, entity in self.petkit_entities.items()
             if isinstance(entity, Litter)
+        ]
+        stats_tasks += [
+            self.populate_pet_feeder_stats(entity)
+            for device_id, entity in self.petkit_entities.items()
+            if isinstance(entity, Feeder)
         ]
         await self._safe_gather(stats_tasks, "stats_tasks")
 
@@ -982,6 +987,82 @@ class PetKitClient:
             elif litter_data.device_nfo.device_type in [T5, T6]:
                 await self.init_pet_stats(pet, litter_data)
                 await self._process_litter_camera(pet, litter_data)
+
+    async def populate_pet_feeder_stats(self, feeder_data: Feeder) -> None:
+        """Collect data from feeder data to populate pet stats.
+
+        Feeders with pet recognition attribute each meal to a pet, in
+        `device_records.eat[].items[].pet_id`. That attribution already arrives on
+        every poll and was simply never surfaced.
+        :param feeder_data: Feeder data.
+        """
+        if not feeder_data.device_nfo:
+            _LOGGER.warning(
+                "No device info for %s can't populate pet infos", feeder_data
+            )
+            return
+
+        pets_list = await self.get_pets_list()
+        for pet in pets_list:
+            await self.init_pet_feeder_stats(pet)
+            await self._process_feeder_records(pet, feeder_data)
+
+    @staticmethod
+    async def init_pet_feeder_stats(pet: Pet) -> None:
+        """Initialize pet feeder stats.
+        Allow pet stats to be displayed in HA even if no data is available.
+        :param pet: Pet data.
+        """
+        if (
+            getattr(pet, "last_meal_time", None) is None
+            and getattr(pet, "last_meal_duration", None) is None
+            and getattr(pet, "last_feeder_used", None) is None
+            and getattr(pet, "meals_today", None) is None
+        ):
+            pet.last_meal_time = 0
+            pet.last_meal_duration = 0
+            pet.last_feeder_used = "Unknown"
+            pet.meals_today = 0
+
+    async def _process_feeder_records(self, pet: Pet, feeder_data: Feeder) -> None:
+        """Process feeder eat records to extract per-pet meal stats.
+        :param pet: Pet data.
+        :param feeder_data: Feeder data.
+        """
+        records = getattr(feeder_data, "device_records", None)
+        if records is None or not getattr(records, "eat", None):
+            return
+
+        device_name = getattr(feeder_data.device_nfo, "device_name", None)
+        meals_today = 0
+
+        for group in records.eat or []:
+            for item in getattr(group, "items", None) or []:
+                # The AI does not recognise every visit; unattributed items carry
+                # no pet_id and must not be counted against any pet.
+                if item.pet_id is None or str(item.pet_id) != str(pet.pet_id):
+                    continue
+                meals_today += 1
+
+                start = item.eat_start_time
+                if start is None:
+                    continue
+                if pet.last_meal_time is None or start > pet.last_meal_time:
+                    self.set_if_not_none(pet, "last_meal_time", start)
+                    # `duration` is a constant in the payload, not the meal length,
+                    # so derive it from the start/end pair instead.
+                    self.set_if_not_none(
+                        pet,
+                        "last_meal_duration",
+                        self.calculate_duration(start, item.eat_end_time),
+                    )
+                    self.set_if_not_none(
+                        pet,
+                        "last_feeder_used",
+                        device_name.capitalize() if device_name is not None else None,
+                    )
+
+        pet.meals_today = meals_today
 
     @staticmethod
     async def init_pet_stats(pet: Pet, litter_data: Litter) -> None:

--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -1012,17 +1012,21 @@ class PetKitClient:
 
     @staticmethod
     def _feeder_has_pet_recognition(feeder_data: Feeder) -> bool:
-        """Return True only if the feeder payload contains at least one
-        eat record item attributed to a pet (i.e. has AI recognition).
+        """Return True if the feeder SUPPORTS pet recognition.
+
+        This is a capability test, not a data test. Looking for an already
+        attributed eat record conflates "cannot do this" with "has not done it
+        yet today": device_records.eat resets daily, and the AI does not
+        recognise every visit, so a data test leaves the stats uninitialised
+        for a window after every midnight.
+
+        `eatDetection` is the per-pet meal-event feature and is only present on
+        feeders that have it. `petDetection` is NOT usable here: it drives the
+        recognition overlay, and turning it off leaves per-pet attribution
+        working.
         """
-        records = getattr(feeder_data, "device_records", None)
-        if records is None or not getattr(records, "eat", None):
-            return False
-        for group in records.eat or []:
-            for item in getattr(group, "items", None) or []:
-                if item.pet_id is not None:
-                    return True
-        return False
+        settings = getattr(feeder_data, "settings", None)
+        return settings is not None and settings.eat_detection is not None
 
     @staticmethod
     async def init_pet_feeder_stats(pet: Pet) -> None:

--- a/pypetkitapi/client.py
+++ b/pypetkitapi/client.py
@@ -1015,8 +1015,8 @@ class PetKitClient:
         """Return True only for camera feeders exposing the AI/pet-recognition mode."""
         device_nfo = feeder_data.device_nfo
         return (
-                device_nfo.device_type in FEEDER_WITH_CAMERA
-                and getattr(device_nfo, "type_code", 0) == 2
+            device_nfo.device_type in FEEDER_WITH_CAMERA
+            and getattr(device_nfo, "type_code", 0) == 2
         )
 
     @staticmethod

--- a/pypetkitapi/containers.py
+++ b/pypetkitapi/containers.py
@@ -195,6 +195,12 @@ class Pet(BaseModel):
     device_nfo: Device | None = None
     pet_details: PetDetails | None = None
 
+    # Feeder stats
+    last_meal_time: int | None = None
+    last_meal_duration: int | None = None
+    last_feeder_used: str | None = None
+    meals_today: int | None = None
+
     # Litter stats
     last_litter_usage: int | None = None
     last_device_used: str | None = None

--- a/tests/test_pet_feeder_stats.py
+++ b/tests/test_pet_feeder_stats.py
@@ -58,7 +58,10 @@ def _feeder() -> Feeder:
         deviceName="yumshare",
         deviceType="d4sh",
         groupId=1,
-        type=1,
+        # real values from a live D4SH-2: type 25, typeCode 2. The guard keys on
+        # typeCode, so a fixture that omits it silently fails every test.
+        type=25,
+        typeCode=2,
         uniqueId="u0001",
     )
     feeder.device_records = FeederRecord(**FAKE_EAT_RECORD)
@@ -130,15 +133,6 @@ class TestPetRecognitionGuard(unittest.IsolatedAsyncioTestCase):
         self.pet_a = _pet(101401310, "Pet A")
         self.client.petkit_entities = {101401310: self.pet_a}
 
-    async def test_non_ai_feeder_gets_no_stats(self) -> None:
-        """A feeder with no eatDetection never gains the four fields."""
-        feeder = _feeder()
-        feeder.settings = SettingsFeeder()
-        feeder.device_records = FeederRecord(**FAKE_EAT_RECORD)
-        await self.client.populate_pet_feeder_stats(feeder)
-        self.assertIsNone(self.pet_a.meals_today)
-        self.assertIsNone(self.pet_a.last_meal_time)
-
     async def test_ai_feeder_initialised_before_first_attributed_meal(self) -> None:
         """Just after the daily reset the AI feeder still reports 0, not None.
 
@@ -173,3 +167,19 @@ class TestPetRecognitionGuard(unittest.IsolatedAsyncioTestCase):
         )
         await self.client.populate_pet_feeder_stats(feeder)
         self.assertEqual(self.pet_a.meals_today, 0)
+
+
+class TestNonAiFeederGuard(unittest.IsolatedAsyncioTestCase):
+    """typeCode separates the recognising hardware from the rest."""
+
+    async def asyncSetUp(self) -> None:
+        self.client = PetKitClient.__new__(PetKitClient)
+        self.pet_a = _pet(101401310, "Pet A")
+        self.client.petkit_entities = {101401310: self.pet_a}
+
+    async def test_camera_feeder_without_recognition_gets_no_stats(self) -> None:
+        feeder = _feeder()
+        feeder.device_nfo.type_code = 1
+        await self.client.populate_pet_feeder_stats(feeder)
+        self.assertIsNone(self.pet_a.meals_today)
+        self.assertIsNone(self.pet_a.last_meal_time)

--- a/tests/test_pet_feeder_stats.py
+++ b/tests/test_pet_feeder_stats.py
@@ -9,9 +9,9 @@ import unittest
 
 from pypetkitapi.client import PetKitClient
 from pypetkitapi.containers import Device, Pet
-from pypetkitapi.feeder_container import Feeder, FeederRecord
+from pypetkitapi.feeder_container import Feeder, FeederRecord, SettingsFeeder
 
-# Cipria ate twice, Tali once, and one visit went unrecognised.
+# Pet A ate twice, Pet B once, and one visit went unrecognised.
 FAKE_EAT_RECORD = {
     "eat": [
         {
@@ -51,6 +51,7 @@ def _feeder() -> Feeder:
     feeder = Feeder(
         id=300035322, name="YumShare", firmware="733", hardware=1, sn="SN0001"
     )
+    feeder.settings = SettingsFeeder(eatDetection=1)
     feeder.device_nfo = Device(
         createdAt=1719234118,
         deviceId=300035322,
@@ -69,53 +70,92 @@ class TestPetFeederStats(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self) -> None:
         self.client = PetKitClient.__new__(PetKitClient)
-        self.cipria = _pet(101401310, "Cipria")
-        self.tali = _pet(101401320, "Tali")
-        self.tea = _pet(101401316, "Tea")
+        self.pet_a = _pet(101401310, "Pet A")
+        self.pet_b = _pet(101401320, "Pet B")
+        self.pet_c = _pet(101401316, "Pet C")
         self.client.petkit_entities = {
-            101401310: self.cipria,
-            101401320: self.tali,
-            101401316: self.tea,
+            101401310: self.pet_a,
+            101401320: self.pet_b,
+            101401316: self.pet_c,
         }
 
     async def test_last_meal_is_the_most_recent_for_that_pet(self) -> None:
         await self.client.populate_pet_feeder_stats(_feeder())
-        # Cipria's later meal wins over her earlier one
-        self.assertEqual(self.cipria.last_meal_time, 1753663000)
-        self.assertEqual(self.cipria.last_meal_duration, 46)
-        self.assertEqual(self.tali.last_meal_time, 1753662700)
-        self.assertEqual(self.tali.last_meal_duration, 138)
+        # the later meal wins over the earlier one for the same pet
+        self.assertEqual(self.pet_a.last_meal_time, 1753663000)
+        self.assertEqual(self.pet_a.last_meal_duration, 46)
+        self.assertEqual(self.pet_b.last_meal_time, 1753662700)
+        self.assertEqual(self.pet_b.last_meal_duration, 138)
 
     async def test_meal_count_ignores_unattributed_visits(self) -> None:
         await self.client.populate_pet_feeder_stats(_feeder())
-        self.assertEqual(self.cipria.meals_today, 2)
-        self.assertEqual(self.tali.meals_today, 1)
+        self.assertEqual(self.pet_a.meals_today, 2)
+        self.assertEqual(self.pet_b.meals_today, 1)
         # the unrecognised visit is counted against nobody
-        self.assertEqual(self.tea.meals_today, 0)
+        self.assertEqual(self.pet_c.meals_today, 0)
 
     async def test_pet_that_did_not_eat_reports_zero_not_none(self) -> None:
         """Sensors must exist from the first poll, so stats initialise to zero."""
         await self.client.populate_pet_feeder_stats(_feeder())
-        self.assertEqual(self.tea.last_meal_time, 0)
-        self.assertEqual(self.tea.last_meal_duration, 0)
-        self.assertEqual(self.tea.last_feeder_used, "Unknown")
+        self.assertEqual(self.pet_c.last_meal_time, 0)
+        self.assertEqual(self.pet_c.last_meal_duration, 0)
+        self.assertEqual(self.pet_c.last_feeder_used, "Unknown")
 
     async def test_feeder_name_is_recorded_for_the_pet_that_ate(self) -> None:
         await self.client.populate_pet_feeder_stats(_feeder())
-        self.assertEqual(self.cipria.last_feeder_used, "Yumshare")
+        self.assertEqual(self.pet_a.last_feeder_used, "Yumshare")
 
     async def test_string_pet_id_matches_integer_pet_id(self) -> None:
         """RecordsItems.pet_id is a str, Pet.pet_id is an int — the join must survive that."""
-        self.assertIsInstance(self.cipria.pet_id, int)
+        self.assertIsInstance(self.pet_a.pet_id, int)
         await self.client.populate_pet_feeder_stats(_feeder())
-        self.assertNotEqual(self.cipria.last_meal_time, 0)
+        self.assertNotEqual(self.pet_a.last_meal_time, 0)
 
     async def test_feeder_without_records_is_harmless(self) -> None:
         feeder = _feeder()
         feeder.device_records = None
         await self.client.populate_pet_feeder_stats(feeder)
-        self.assertEqual(self.cipria.last_meal_time, 0)
+        self.assertEqual(self.pet_a.last_meal_time, 0)
 
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPetRecognitionGuard(unittest.IsolatedAsyncioTestCase):
+    """The guard must key on CAPABILITY, not on whether a pet has eaten yet."""
+
+    async def asyncSetUp(self) -> None:
+        self.client = PetKitClient.__new__(PetKitClient)
+        self.pet_a = _pet(101401310, "Pet A")
+        self.client.petkit_entities = {101401310: self.pet_a}
+
+    async def test_non_ai_feeder_gets_no_stats(self) -> None:
+        """A feeder with no eatDetection never gains the four fields."""
+        feeder = _feeder()
+        feeder.settings = SettingsFeeder()
+        feeder.device_records = FeederRecord(**FAKE_EAT_RECORD)
+        await self.client.populate_pet_feeder_stats(feeder)
+        self.assertIsNone(self.pet_a.meals_today)
+        self.assertIsNone(self.pet_a.last_meal_time)
+
+    async def test_ai_feeder_initialised_before_first_attributed_meal(self) -> None:
+        """Just after the daily reset the AI feeder still reports 0, not None.
+
+        device_records.eat resets at local midnight, so between then and the
+        first RECOGNISED meal there is nothing attributed to find. A data-based
+        guard blanks the sensors for that whole window.
+        """
+        feeder = _feeder()
+        feeder.device_records = None
+        await self.client.populate_pet_feeder_stats(feeder)
+        self.assertEqual(self.pet_a.meals_today, 0)
+        self.assertEqual(self.pet_a.last_meal_time, 0)
+
+    async def test_ai_feeder_with_only_unrecognised_meals(self) -> None:
+        """Meals happened but the AI named nobody: still initialised, count 0."""
+        feeder = _feeder()
+        feeder.device_records = FeederRecord(**{"eat": [{"deviceId": 300035322, "items": [
+            {"eatStartTime": 1753662133, "eatEndTime": 1753662301, "duration": 4}]}]})
+        await self.client.populate_pet_feeder_stats(feeder)
+        self.assertEqual(self.pet_a.meals_today, 0)

--- a/tests/test_pet_feeder_stats.py
+++ b/tests/test_pet_feeder_stats.py
@@ -155,7 +155,21 @@ class TestPetRecognitionGuard(unittest.IsolatedAsyncioTestCase):
     async def test_ai_feeder_with_only_unrecognised_meals(self) -> None:
         """Meals happened but the AI named nobody: still initialised, count 0."""
         feeder = _feeder()
-        feeder.device_records = FeederRecord(**{"eat": [{"deviceId": 300035322, "items": [
-            {"eatStartTime": 1753662133, "eatEndTime": 1753662301, "duration": 4}]}]})
+        feeder.device_records = FeederRecord(
+            **{
+                "eat": [
+                    {
+                        "deviceId": 300035322,
+                        "items": [
+                            {
+                                "eatStartTime": 1753662133,
+                                "eatEndTime": 1753662301,
+                                "duration": 4,
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
         await self.client.populate_pet_feeder_stats(feeder)
         self.assertEqual(self.pet_a.meals_today, 0)

--- a/tests/test_pet_feeder_stats.py
+++ b/tests/test_pet_feeder_stats.py
@@ -1,0 +1,121 @@
+"""Per-pet meal attribution from feeder records.
+
+The payload shape below is a trimmed copy of a real `getDeviceRecord` response for
+a D4SH with pet recognition: `eat[].items[]` carries `petId` for every meal the AI
+managed to attribute, and leaves it out for the ones it did not.
+"""
+
+import unittest
+
+from pypetkitapi.client import PetKitClient
+from pypetkitapi.containers import Device, Pet
+from pypetkitapi.feeder_container import Feeder, FeederRecord
+
+# Cipria ate twice, Tali once, and one visit went unrecognised.
+FAKE_EAT_RECORD = {
+    "eat": [
+        {
+            "deviceId": 300035322,
+            "items": [
+                {
+                    "eatStartTime": 1753662133,
+                    "eatEndTime": 1753662301,
+                    "petId": "101401310",
+                    "duration": 4,
+                },
+                {
+                    "eatStartTime": 1753662700,
+                    "eatEndTime": 1753662838,
+                    "petId": "101401320",
+                    "duration": 4,
+                },
+                {
+                    "eatStartTime": 1753663000,
+                    "eatEndTime": 1753663046,
+                    "petId": "101401310",
+                    "duration": 4,
+                },
+                # no petId: the AI did not recognise the cat
+                {"eatStartTime": 1753663500, "eatEndTime": 1753663560, "duration": 4},
+            ],
+        }
+    ]
+}
+
+
+def _pet(pet_id: int, name: str) -> Pet:
+    return Pet(avatar="", createdAt=0, petId=pet_id, petName=name)
+
+
+def _feeder() -> Feeder:
+    feeder = Feeder(
+        id=300035322, name="YumShare", firmware="733", hardware=1, sn="SN0001"
+    )
+    feeder.device_nfo = Device(
+        createdAt=1719234118,
+        deviceId=300035322,
+        deviceName="yumshare",
+        deviceType="d4sh",
+        groupId=1,
+        type=1,
+        uniqueId="u0001",
+    )
+    feeder.device_records = FeederRecord(**FAKE_EAT_RECORD)
+    return feeder
+
+
+class TestPetFeederStats(unittest.IsolatedAsyncioTestCase):
+    """Per-pet feeder stats derived from eat records."""
+
+    async def asyncSetUp(self) -> None:
+        self.client = PetKitClient.__new__(PetKitClient)
+        self.cipria = _pet(101401310, "Cipria")
+        self.tali = _pet(101401320, "Tali")
+        self.tea = _pet(101401316, "Tea")
+        self.client.petkit_entities = {
+            101401310: self.cipria,
+            101401320: self.tali,
+            101401316: self.tea,
+        }
+
+    async def test_last_meal_is_the_most_recent_for_that_pet(self) -> None:
+        await self.client.populate_pet_feeder_stats(_feeder())
+        # Cipria's later meal wins over her earlier one
+        self.assertEqual(self.cipria.last_meal_time, 1753663000)
+        self.assertEqual(self.cipria.last_meal_duration, 46)
+        self.assertEqual(self.tali.last_meal_time, 1753662700)
+        self.assertEqual(self.tali.last_meal_duration, 138)
+
+    async def test_meal_count_ignores_unattributed_visits(self) -> None:
+        await self.client.populate_pet_feeder_stats(_feeder())
+        self.assertEqual(self.cipria.meals_today, 2)
+        self.assertEqual(self.tali.meals_today, 1)
+        # the unrecognised visit is counted against nobody
+        self.assertEqual(self.tea.meals_today, 0)
+
+    async def test_pet_that_did_not_eat_reports_zero_not_none(self) -> None:
+        """Sensors must exist from the first poll, so stats initialise to zero."""
+        await self.client.populate_pet_feeder_stats(_feeder())
+        self.assertEqual(self.tea.last_meal_time, 0)
+        self.assertEqual(self.tea.last_meal_duration, 0)
+        self.assertEqual(self.tea.last_feeder_used, "Unknown")
+
+    async def test_feeder_name_is_recorded_for_the_pet_that_ate(self) -> None:
+        await self.client.populate_pet_feeder_stats(_feeder())
+        self.assertEqual(self.cipria.last_feeder_used, "Yumshare")
+
+    async def test_string_pet_id_matches_integer_pet_id(self) -> None:
+        """RecordsItems.pet_id is a str, Pet.pet_id is an int — the join must survive that."""
+        self.assertIsInstance(self.cipria.pet_id, int)
+        await self.client.populate_pet_feeder_stats(_feeder())
+        self.assertNotEqual(self.cipria.last_meal_time, 0)
+
+    async def test_feeder_without_records_is_harmless(self) -> None:
+        feeder = _feeder()
+        feeder.device_records = None
+        await self.client.populate_pet_feeder_stats(feeder)
+        self.assertEqual(self.cipria.last_meal_time, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Feeders with pet recognition already attribute every meal to a pet, in `device_records.eat[].items[].pet_id`. That data arrives on every poll and is never surfaced, so a household with a recognising feeder and no litter box gets no per-pet information at all — while litter box owners get `last_litter_usage`, `last_duration_usage`, `last_device_used` and friends.

## Change

Adds `last_meal_time`, `last_meal_duration`, `last_feeder_used` and `meals_today` to `Pet`, populated by `populate_pet_feeder_stats()`.

This is deliberately the same shape as the existing `populate_pet_stats()` for litters — same `init_*_stats` step so the sensors exist from the first poll, same `set_if_not_none` usage, same dispatch from `_execute_stats_tasks()`.

## Three details worth flagging for review

- **Meal length is `eatEndTime - eatStartTime`.** The `duration` field in the payload is a constant — 4 in every sample I captured — and is not the meal length.
- **`RecordsItems.pet_id` is a `str` while `Pet.pet_id` is an `int`**, unlike `LitterRecord` where both are ints, so the join normalises to `str`. Happy to change the model instead if you would prefer the types aligned.
- **Not every visit is recognised.** Items without a `pet_id` are counted against nobody rather than attributed to an arbitrary pet.

## Testing

`tests/test_pet_feeder_stats.py` covers this against a trimmed real D4SH payload: most-recent-meal-wins, unattributed visits excluded from the count, pets that did not eat reporting zero rather than `None`, the feeder name, and the str/int join.

```
84 passed
```

Verified against a live D4SH-2 with three recognised cats. The companion Home Assistant sensors are in a matching PR on `homeassistant_petkit`.